### PR TITLE
Make up/down ingress/egress less ambiguous for paths (#1479)

### DIFF
--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -62,7 +62,7 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, error) {
 	if err != nil {
 		return HookError, nil, err
 	}
-	if currHopF.Ingress != 0 || currHopF.Egress != 0 {
+	if currHopF.ConsIngress != 0 || currHopF.ConsEgress != 0 {
 		// The current hop field has already been generated.
 		return HookContinue, nil, nil
 	}

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -237,22 +237,22 @@ func (rp *RtrPkt) getHopFVer(dirFrom rcmn.Dir) common.RawBytes {
 			// interface, and another from the upstream interface, used for
 			// verification only.
 			switch {
-			case ingress && rp.infoF.Up:
+			case ingress && !rp.infoF.ConsDir:
 				offset = +2
-			case ingress && !rp.infoF.Up:
+			case ingress && rp.infoF.ConsDir:
 				offset = +1
-			case !ingress && rp.infoF.Up:
+			case !ingress && !rp.infoF.ConsDir:
 				offset = -1
-			case !ingress && !rp.infoF.Up:
+			case !ingress && rp.infoF.ConsDir:
 				offset = -2
 			}
 		case false:
 			// Non-peer shortcut paths have an extra HOF above the last hop,
 			// used for verification of the last hop in that segment.
 			switch {
-			case ingress && !rp.infoF.Up:
+			case ingress && rp.infoF.ConsDir:
 				offset = -1
-			case !ingress && rp.infoF.Up:
+			case !ingress && !rp.infoF.ConsDir:
 				offset = +1
 			}
 		}
@@ -268,13 +268,13 @@ func (rp *RtrPkt) getHopFVerNormalOffset() int {
 	hOff := rp.CmnHdr.HopFOffBytes()
 	// If this is the last hop of an Up path, or the first hop of a Down path, there's no previous
 	// HOF to verify against.
-	if (rp.infoF.Up &&
+	if (!rp.infoF.ConsDir &&
 		hOff == (iOff+spath.InfoFieldLength+int(rp.infoF.Hops-1)*spath.HopFieldLength)) ||
-		(!rp.infoF.Up && hOff == (iOff+spath.InfoFieldLength)) {
+		(rp.infoF.ConsDir && hOff == (iOff+spath.InfoFieldLength)) {
 		return 0
 	}
 	// Otherwise use the next/prev HOF based on the up flag.
-	if rp.infoF.Up {
+	if !rp.infoF.ConsDir {
 		return 1
 	}
 	return -1
@@ -393,7 +393,8 @@ func (rp *RtrPkt) UpFlag() (*bool, error) {
 	if rp.infoF == nil {
 		return nil, nil
 	}
-	rp.upFlag = &rp.infoF.Up
+	upFlag := !rp.infoF.ConsDir
+	rp.upFlag = &upFlag
 	return rp.upFlag, nil
 }
 
@@ -422,9 +423,9 @@ func (rp *RtrPkt) IFCurr() (*common.IFIDType, error) {
 					"val", rp.DirFrom)
 			}
 			if ingress {
-				return rp.checkSetCurrIF(&rp.hopF.Ingress)
+				return rp.checkSetCurrIF(&rp.hopF.ConsIngress)
 			}
-			return rp.checkSetCurrIF(&rp.hopF.Egress)
+			return rp.checkSetCurrIF(&rp.hopF.ConsEgress)
 		}
 	}
 	// Default to the first IfID from Ingress.IfIDs
@@ -457,9 +458,9 @@ func (rp *RtrPkt) IFNext() (*common.IFIDType, error) {
 		}
 		// Get IFID from HopField
 		if *rp.upFlag {
-			rp.ifNext = &rp.hopF.Ingress
+			rp.ifNext = &rp.hopF.ConsIngress
 		} else {
-			rp.ifNext = &rp.hopF.Egress
+			rp.ifNext = &rp.hopF.ConsEgress
 		}
 	}
 	return rp.ifNext, nil

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -227,7 +227,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 		}
 		origIF := origIFNext
 		newIF := *rp.ifNext
-		if infoF.Up {
+		if !infoF.ConsDir {
 			rp.ifCurr = nil
 			if _, err = rp.IFCurr(); err != nil {
 				return err
@@ -256,7 +256,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil))
 	}
 	// Only allowed to switch from up- to up-segment if the next link is CORE.
-	if infoF.Up && rp.infoF.Up && nextLink != topology.CoreLink {
+	if !infoF.ConsDir && !rp.infoF.ConsDir && nextLink != topology.CoreLink {
 		return common.NewBasicError(
 			"Segment change from up segment to up segment with non-CORE next link",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil),
@@ -264,7 +264,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 		)
 	}
 	// Only allowed to switch from down- to down-segment if the previous link is CORE.
-	if !infoF.Up && !rp.infoF.Up && prevLink != topology.CoreLink {
+	if infoF.ConsDir && rp.infoF.ConsDir && prevLink != topology.CoreLink {
 		return common.NewBasicError(
 			"Segment change from down segment to down segment with non-CORE previous link",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil),

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -78,8 +78,8 @@ func (ps *PathSegment) ID() (common.RawBytes, error) {
 			if err != nil {
 				return nil, err
 			}
-			binary.Write(h, common.Order, hopf.Ingress)
-			binary.Write(h, common.Order, hopf.Egress)
+			binary.Write(h, common.Order, hopf.ConsIngress)
+			binary.Write(h, common.Order, hopf.ConsEgress)
 		}
 		ps.id = h.Sum(nil)
 	}
@@ -203,12 +203,12 @@ func (ps *PathSegment) String() string {
 			continue
 		}
 		hop_desc := []string{}
-		if hop.Ingress > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.Ingress))
+		if hop.ConsIngress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.ConsIngress))
 		}
 		hop_desc = append(hop_desc, ase.IA().String())
-		if hop.Egress > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.Egress))
+		if hop.ConsEgress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.ConsEgress))
 		}
 		hops_desc = append(hops_desc, strings.Join(hop_desc, ""))
 	}

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -292,15 +292,15 @@ func (b *Backend) insertInterfaces(ases []*seg.ASEntry, segRowID int64) error {
 			if err != nil {
 				return common.NewBasicError("Failed to extract hop field", err)
 			}
-			if hof.Ingress != 0 {
-				_, err = stmt.Exec(ia.I, ia.A, hof.Ingress, segRowID)
+			if hof.ConsIngress != 0 {
+				_, err = stmt.Exec(ia.I, ia.A, hof.ConsIngress, segRowID)
 				if err != nil {
 					return common.NewBasicError("Failed to insert Ingress into IntfToSeg", err)
 				}
 			}
 			// Only insert the Egress interface for the first hop entry in an AS entry.
-			if idx == 0 && hof.Egress != 0 {
-				_, err := stmt.Exec(ia.I, ia.A, hof.Egress, segRowID)
+			if idx == 0 && hof.ConsEgress != 0 {
+				_, err := stmt.Exec(ia.I, ia.A, hof.ConsEgress, segRowID)
 				if err != nil {
 					return common.NewBasicError("Failed to insert Egress into IntfToSeg", err)
 				}

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -32,8 +32,8 @@ type HopField struct {
 	ForwardOnly bool
 	Recurse     bool
 	ExpTime     uint8
-	Ingress     common.IFIDType
-	Egress      common.IFIDType
+	ConsIngress common.IFIDType
+	ConsEgress  common.IFIDType
 	Mac         common.RawBytes
 	length      int
 }
@@ -51,8 +51,8 @@ func NewHopField(b common.RawBytes, in common.IFIDType, out common.IFIDType) *Ho
 	h := &HopField{}
 	h.data = b
 	h.ExpTime = DefaultHopFExpiry
-	h.Ingress = in
-	h.Egress = out
+	h.ConsIngress = in
+	h.ConsEgress = out
 	h.Write()
 	return h
 }
@@ -73,8 +73,8 @@ func HopFFromRaw(b []byte) (*HopField, error) {
 	h.ExpTime = h.data[offset]
 	offset += 1
 	// Interface IDs are 12b each, encoded into 3B
-	h.Ingress = common.IFIDType(int(h.data[offset])<<4 | int(h.data[offset+1])>>4)
-	h.Egress = common.IFIDType((int(h.data[offset+1])&0xF)<<8 | int(h.data[offset+2]))
+	h.ConsIngress = common.IFIDType(int(h.data[offset])<<4 | int(h.data[offset+1])>>4)
+	h.ConsEgress = common.IFIDType((int(h.data[offset+1])&0xF)<<8 | int(h.data[offset+2]))
 	offset += 3
 	h.Mac = h.data[offset:]
 	h.length = common.LineLen
@@ -103,16 +103,16 @@ func (h *HopField) Write() {
 	h.data[0] = flags
 	h.data[1] = h.ExpTime
 	// Interface IDs are 12b each, encoded into 3B
-	h.data[2] = byte(h.Ingress >> 4)
-	h.data[3] = byte((h.Ingress&0x0F)<<4 | h.Egress>>8)
-	h.data[4] = byte(h.Egress & 0xFF)
+	h.data[2] = byte(h.ConsIngress >> 4)
+	h.data[3] = byte((h.ConsIngress&0x0F)<<4 | h.ConsEgress>>8)
+	h.data[4] = byte(h.ConsEgress & 0xFF)
 	copy(h.data[5:], h.Mac)
 }
 
 func (h *HopField) String() string {
 	return fmt.Sprintf(
-		"Ingress: %v Egress: %v ExpTime: %v Xover: %v VerifyOnly: %v ForwardOnly: %v Mac: %v",
-		h.Ingress, h.Egress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
+		"ConsIngress: %v ConsEgress: %v ExpTime: %v Xover: %v VerifyOnly: %v ForwardOnly: %v Mac: %v",
+		h.ConsIngress, h.ConsEgress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
 }
 
 func (h *HopField) Verify(mac hash.Hash, tsInt uint32, prev common.RawBytes) error {

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -29,7 +29,8 @@ const (
 )
 
 type InfoField struct {
-	Up       bool
+	// !Up
+	ConsDir  bool
 	Shortcut bool
 	Peer     bool
 	TsInt    uint32
@@ -44,7 +45,7 @@ func InfoFFromRaw(b []byte) (*InfoField, error) {
 	}
 	inf := &InfoField{}
 	flags := b[0]
-	inf.Up = flags&0x1 != 0
+	inf.ConsDir = flags&0x1 == 0
 	inf.Shortcut = flags&0x2 != 0
 	inf.Peer = flags&0x4 != 0
 	offset := 1
@@ -58,7 +59,7 @@ func InfoFFromRaw(b []byte) (*InfoField, error) {
 
 func (inf *InfoField) Write(b common.RawBytes) {
 	b[0] = 0
-	if inf.Up {
+	if !inf.ConsDir {
 		b[0] |= 0x1
 	}
 	if inf.Shortcut {
@@ -76,8 +77,8 @@ func (inf *InfoField) Write(b common.RawBytes) {
 }
 
 func (inf *InfoField) String() string {
-	return fmt.Sprintf("ISD: %v TS: %v Hops: %v Up: %v Shortcut: %v Peer: %v",
-		inf.ISD, inf.Timestamp(), inf.Hops, inf.Up, inf.Shortcut, inf.Peer)
+	return fmt.Sprintf("ISD: %v TS: %v Hops: %v ConsDir: %v Shortcut: %v Peer: %v",
+		inf.ISD, inf.Timestamp(), inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
 }
 
 func (inf *InfoField) Timestamp() time.Time {

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -82,7 +82,7 @@ func (p *Path) Reverse() error {
 			p.InfOff = revOff
 		}
 		infoF := infoFs[i]
-		infoF.Up = !infoF.Up // Reverse Up flag
+		infoF.ConsDir = !infoF.ConsDir // Reverse Up/ConsDir flag
 		infoF.Write(revRaw[revOff:])
 		infoF, _ = InfoFFromRaw(revRaw[revOff:])
 		revOff += InfoFieldLength

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -90,7 +90,7 @@ func Test_Path_Reverse(t *testing.T) {
 					prefix := fmt.Sprintf("seg %d", seg)
 					infof, err := InfoFFromRaw(path.Raw[offset:])
 					SoMsg(prefix+" InfoF parse", err, ShouldBeNil)
-					SoMsg(prefix+" InfoF up", infof.Up, ShouldEqual, out.up)
+					SoMsg(prefix+" InfoF up", !infof.ConsDir, ShouldEqual, out.up)
 					SoMsg(prefix+" InfoF ISD "+infof.String(),
 						infof.ISD, ShouldEqual, len(c.in)-seg-1)
 					SoMsg(prefix+" InfoF Offset", path.InfOff, ShouldEqual, c.outOffs[j][0])
@@ -125,7 +125,7 @@ func mkPathRevCase(in []pathCase, inInfOff, inHopfOff int) *Path {
 }
 
 func makeSeg(b common.RawBytes, up bool, isd uint16, hops []uint8) {
-	infof := InfoField{Up: up, ISD: isd, Hops: uint8(len(hops))}
+	infof := InfoField{ConsDir: !up, ISD: isd, Hops: uint8(len(hops))}
 	infof.Write(b)
 	for i, hop := range hops {
 		for j := 0; j < HopFieldLength; j++ {

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -219,21 +219,21 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             BEACONS_PROPAGATED.labels(**self._labels, type="down").inc(prop_cnt)
         return propagated_pcbs
 
-    def _mk_prop_pcb_meta(self, pcb, dst_ia, egress_if):
+    def _mk_prop_pcb_meta(self, pcb, dst_ia, cons_egress_if):
         ts = pcb.get_timestamp()
-        asm = self._create_asm(pcb.ifID, egress_if, ts, pcb.last_hof())
+        asm = self._create_asm(pcb.ifID, cons_egress_if, ts, pcb.last_hof())
         if not asm:
             return None, None
         pcb.add_asm(asm, ProtoSignType.ED25519, self.addr.isd_as.pack())
         pcb.sign(self.signing_key)
-        one_hop_path = self._create_one_hop_path(egress_if)
+        one_hop_path = self._create_one_hop_path(cons_egress_if)
         return pcb, self._build_meta(ia=dst_ia, host=SVCType.BS_A,
                                      path=one_hop_path, one_hop=True)
 
-    def _create_one_hop_path(self, egress_if):
+    def _create_one_hop_path(self, cons_egress_if):
         ts = int(SCIONTime.get_time())
         info = InfoOpaqueField.from_values(ts, self.addr.isd_as[0], hops=2)
-        hf1 = HopOpaqueField.from_values(OneHopPathExt.HOF_EXP_TIME, 0, egress_if)
+        hf1 = HopOpaqueField.from_values(OneHopPathExt.HOF_EXP_TIME, 0, cons_egress_if)
         hf1.set_mac(self.of_gen_key, ts, None)
         # Return a path where second HF is empty.
         return SCIONPath.from_values(info, [hf1, HopOpaqueField()])
@@ -299,7 +299,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         assert isinstance(pcb, PCB), type(pcb)
         pcb = pcb.pseg()
         if meta:
-            pcb.ifID = meta.path.get_hof().ingress_if
+            pcb.ifID = meta.path.get_hof().cons_ingress_if
         try:
             self.path_policy.check_filters(pcb)
         except SCIONPathPolicyViolated as e:

--- a/python/lib/packet/opaque_field.py
+++ b/python/lib/packet/opaque_field.py
@@ -53,8 +53,8 @@ class HopOpaqueField(OpaqueField):
         self.forward_only = False
         self.recurse = False
         self.exp_time = 0
-        self.ingress_if = 0
-        self.egress_if = 0
+        self.cons_ingress_if = 0
+        self.cons_egress_if = 0
         self.mac = bytes(self.MAC_LEN)
         super().__init__(raw)
 
@@ -63,8 +63,8 @@ class HopOpaqueField(OpaqueField):
         flags, self.exp_time = struct.unpack("!BB", data.pop(2))
         self._parse_flags(flags)
         ifs = int.from_bytes(data.pop(3), byteorder="big")
-        self.ingress_if = (ifs & 0xFFF000) >> 12
-        self.egress_if = ifs & 0x000FFF
+        self.cons_ingress_if = (ifs & 0xFFF000) >> 12
+        self.cons_egress_if = ifs & 0x000FFF
         self.mac = data.pop(3)
 
     def _parse_flags(self, flags):  # pragma: no cover
@@ -74,7 +74,7 @@ class HopOpaqueField(OpaqueField):
         self.recurse = bool(flags & HopOFFlags.RECURSE)
 
     @classmethod
-    def from_values(cls, exp_time, ingress_if=0, egress_if=0,
+    def from_values(cls, exp_time, cons_ingress_if=0, cons_egress_if=0,
                     mac=None, xover=False, verify_only=False,
                     forward_only=False, recurse=False):  # pragma: no cover
         inst = cls()
@@ -83,8 +83,8 @@ class HopOpaqueField(OpaqueField):
         inst.forward_only = forward_only
         inst.recurse = recurse
         inst.exp_time = exp_time
-        inst.ingress_if = ingress_if
-        inst.egress_if = egress_if
+        inst.cons_ingress_if = cons_ingress_if
+        inst.cons_egress_if = cons_egress_if
         inst.mac = mac or bytes(inst.MAC_LEN)
         return inst
 
@@ -95,7 +95,7 @@ class HopOpaqueField(OpaqueField):
             flags &= self.VERIFY_FLAGS
         packed.append(struct.pack("!B", flags))
         packed.append(struct.pack("!B", self.exp_time))
-        ifs = (self.ingress_if << 12) | self.egress_if
+        ifs = (self.cons_ingress_if << 12) | self.cons_egress_if
         # Ingress and egress interfaces are packed into three bytes
         packed.append(ifs.to_bytes(3, "big"))
         if not mac:
@@ -133,8 +133,8 @@ class HopOpaqueField(OpaqueField):
 
     def __eq__(self, other):  # pragma: no cover
         return (self.exp_time == other.exp_time and
-                self.ingress_if == other.ingress_if and
-                self.egress_if == other.egress_if and
+                self.cons_ingress_if == other.cons_ingress_if and
+                self.cons_egress_if == other.cons_egress_if and
                 self.mac == other.mac)
 
     def __str__(self):
@@ -142,7 +142,7 @@ class HopOpaqueField(OpaqueField):
         return ("%s(%dB): flags: %s, exp_time: %s, "
                 "ingress: %s, egress: %s, mac: %s" %
                 (self.NAME, len(self), HopOFFlags.to_str(flags), self.exp_time,
-                 self.ingress_if, self.egress_if, hex_str(self.mac)))
+                 self.cons_ingress_if, self.cons_egress_if, hex_str(self.mac)))
 
 
 class InfoOpaqueField(OpaqueField):
@@ -156,7 +156,7 @@ class InfoOpaqueField(OpaqueField):
     NAME = "InfoOpaqueField"
 
     def __init__(self, raw=None):  # pragma: no cover
-        self.up_flag = False
+        self.cons_dir_flag = True
         self.shortcut = False
         self.peer = False
         self.timestamp = 0
@@ -172,7 +172,7 @@ class InfoOpaqueField(OpaqueField):
 
     def _parse_flags(self, flags):  # pragma: no cover
         if flags & InfoOFFlags.UP:
-            self.up_flag = True
+            self.cons_dir_flag = False
         if flags & InfoOFFlags.SHORTCUT:
             self.shortcut = True
         if flags & InfoOFFlags.PEER_SHORTCUT:
@@ -184,10 +184,10 @@ class InfoOpaqueField(OpaqueField):
         assert not(not self.shortcut and self.peer)
 
     @classmethod
-    def from_values(cls, timestamp, isd, up_flag=False, shortcut=False,
+    def from_values(cls, timestamp, isd, cons_dir_flag=True, shortcut=False,
                     peer=False, hops=0):  # pragma: no cover
         inst = cls()
-        inst.up_flag = up_flag
+        inst.cons_dir_flag =cons_dir_flag
         inst.shortcut = shortcut
         inst.peer = peer
         inst.timestamp = timestamp
@@ -203,7 +203,7 @@ class InfoOpaqueField(OpaqueField):
     def _pack_flags(self):  # pragma: no cover
         self._check_flags()
         flags = 0
-        if self.up_flag:
+        if not self.cons_dir_flag:
             flags |= InfoOFFlags.UP
         if self.shortcut:
             flags |= InfoOFFlags.SHORTCUT
@@ -374,9 +374,9 @@ class OpaqueFieldList(object):
             raise SCIONKeyError("Opaque field label (%s) unknown"
                                 % label) from None
 
-    def reverse_up_flag(self, label):
+    def reverse_cons_dir_flag(self, label):
         """
-        Reverse the Up flag of the first OF in a label, assuming the label isn't
+        Reverse the Up/ConsDir flag of the first OF in a label, assuming the label isn't
         empty. Used to change direction of IOFs.
 
         :param str label: The label to modify.
@@ -389,7 +389,7 @@ class OpaqueFieldList(object):
             raise SCIONKeyError("Opaque field label (%s) unknown"
                                 % label) from None
         if len(group) > 0:
-            group[0].up_flag ^= True
+            group[0].cons_dir_flag ^= True
 
     def pack(self):
         """

--- a/python/lib/packet/path.py
+++ b/python/lib/packet/path.py
@@ -162,7 +162,7 @@ class SCIONPath(Serializable):
             self._ofs.swap(self.A_HOFS, swap_hof)
         # Reverse IOF flags.
         for label in self.IOF_LABELS:
-            self._ofs.reverse_up_flag(label)
+            self._ofs.reverse_cons_dir_flag(label)
         # Reverse HOF lists.
         for label in self.HOF_LABELS:
             self._ofs.reverse_label(label)
@@ -204,7 +204,7 @@ class SCIONPath(Serializable):
                           (False, True): +1, (False, False): None}
         # Map the local direction of travel and the IOF up flag to the required
         # offset of the verification HOF (or None, if there's no relevant HOF).
-        offset = ingress_up[ingress, iof.up_flag]
+        offset = ingress_up[ingress, not iof.cons_dir_flag]
         if offset is None:
             return None
         return self._ofs.get_by_idx(self._hof_idx + offset)
@@ -212,11 +212,11 @@ class SCIONPath(Serializable):
     def _get_hof_ver_normal(self, iof):
         # If this is the last hop of an Up path, or the first hop of a Down
         # path, there's no previous HOF to verify against.
-        if (iof.up_flag and self._hof_idx == self._iof_idx + iof.hops) or (
-                not iof.up_flag and self._hof_idx == self._iof_idx + 1):
+        if (not iof.cons_dir_flag and self._hof_idx == self._iof_idx + iof.hops) or (
+                iof.cons_dir_flag and self._hof_idx == self._iof_idx + 1):
             return None
         # Otherwise use the next/prev HOF based on the up flag.
-        offset = 1 if iof.up_flag else -1
+        offset = 1 if not iof.cons_dir_flag else -1
         return self._ofs.get_by_idx(self._hof_idx + offset)
 
     def get_iof(self):  # pragma: no cover
@@ -261,9 +261,9 @@ class SCIONPath(Serializable):
             return 0
         iof = self.get_iof()
         hof = self.get_hof()
-        if iof.up_flag:
-            return hof.ingress_if
-        return hof.egress_if
+        if not iof.cons_dir_flag:
+            return hof.cons_ingress_if
+        return hof.cons_egress_if
 
     def get_curr_if(self, ingress=True):  # pragma: no cover
         """
@@ -272,9 +272,9 @@ class SCIONPath(Serializable):
         """
         hof = self.get_hof()
         iof = self.get_iof()
-        if ingress == iof.up_flag:
-            return hof.egress_if
-        return hof.ingress_if
+        if ingress != iof.cons_dir_flag:
+            return hof.cons_egress_if
+        return hof.cons_ingress_if
 
     def get_as_hops(self):
         total = 0

--- a/python/lib/packet/pcb.py
+++ b/python/lib/packet/pcb.py
@@ -214,7 +214,7 @@ class PathSegment(Cerealizable):
         asms = list(self.iter_asms())
         if reverse_direction:
             asms = reversed(asms)
-            info.up_flag ^= True
+            info.cons_dir_flag ^= True
         for asm in asms:
             hofs.append(asm.pcbm(0).hof())
         return SCIONPath.from_values(info, hofs)
@@ -240,7 +240,7 @@ class PathSegment(Cerealizable):
             pcbm = asm.pcbm(0)
             data.append(asm.isd_as().pack())
             hof = pcbm.hof()
-            data.append(struct.pack("!QQ", hof.ingress_if, hof.egress_if))
+            data.append(struct.pack("!QQ", hof.cons_ingress_if, hof.cons_egress_if))
         data = b"".join(data)
         if hex:
             return crypto_hash(data).hex()
@@ -287,11 +287,11 @@ class PathSegment(Cerealizable):
         for asm in self.iter_asms():
             hop = []
             hof = asm.pcbm(0).hof()
-            if hof.ingress_if:
-                hop.append("%d " % hof.ingress_if)
+            if hof.cons_ingress_if:
+                hop.append("%d " % hof.cons_ingress_if)
             hop.append("%s" % asm.isd_as())
-            if hof.egress_if:
-                hop.append(" %d" % hof.egress_if)
+            if hof.cons_egress_if:
+                hop.append(" %d" % hof.cons_egress_if)
             hops.append("".join(hop))
         exts = []
         desc.append(">".join(hops))

--- a/python/lib/path_combinator.py
+++ b/python/lib/path_combinator.py
@@ -78,16 +78,16 @@ def _build_shortcuts(up_segment, down_segment, peer_revs):
         return _join_xovr(up_segment, down_segment, xovr)
 
 
-def _copy_segment(segment, xover_start, xover_end, up=True):
+def _copy_segment(segment, xover_start, xover_end, cons_dir=False):
     """
-    Copy a :any:`PathSegment`, setting the up flag, the crossover point
+    Copy a :any:`PathSegment`, setting the up/consDir flag, the crossover point
     flags, and optionally reversing the hops.
     """
     if not segment:
         return None, None, float("inf")
     info = segment.infoF()
-    info.up_flag = up
-    hofs, mtu = _copy_hofs(segment.iter_asms(), reverse=up)
+    info.cons_dir_flag = cons_dir
+    hofs, mtu = _copy_hofs(segment.iter_asms(), reverse=(not cons_dir))
     if xover_start:
         hofs[0].xover = True
     if xover_end:
@@ -142,7 +142,7 @@ def _join_xovr(up_segment, down_segment, point):
     up_iof, up_hofs, up_upstream_hof, up_mtu = \
         _copy_segment_shortcut(up_segment, up_index)
     down_iof, down_hofs, down_upstream_hof, down_mtu = \
-        _copy_segment_shortcut(down_segment, down_index, up=False)
+        _copy_segment_shortcut(down_segment, down_index, cons_dir=True)
 
     up_iof.shortcut = down_iof.shortcut = True
     up_iof.peer = down_iof.peer = False
@@ -172,7 +172,7 @@ def _join_peer(up_segment, down_segment, point, peer_revs):
     up_iof, up_hofs, up_upstream_hof, up_mtu = \
         _copy_segment_shortcut(up_segment, up_index)
     down_iof, down_hofs, down_upstream_hof, down_mtu = \
-        _copy_segment_shortcut(down_segment, down_index, up=False)
+        _copy_segment_shortcut(down_segment, down_index, cons_dir=True)
     up_iof.shortcut = down_iof.shortcut = True
     up_iof.peer = down_iof.peer = True
     path_metas = []
@@ -231,15 +231,15 @@ def _build_shortcut_interface_list(
         up_ia = up_seg.asm(up_idx).isd_as()
         down_ia = down_seg.asm(down_idx).isd_as()
         if_list.append(
-            PathInterface.from_values(up_ia, up_peer_hof.ingress_if))
+            PathInterface.from_values(up_ia, up_peer_hof.cons_ingress_if))
         if_list.append(
-            PathInterface.from_values(down_ia, down_peer_hof.ingress_if))
+            PathInterface.from_values(down_ia, down_peer_hof.cons_ingress_if))
     asm_list = list(down_seg.iter_asms(down_idx))
-    if_list += _build_interface_list(asm_list, up=False)
+    if_list += _build_interface_list(asm_list, cons_dir=True)
     return if_list
 
 
-def _build_interface_list(asms, up=True):
+def _build_interface_list(asms, cons_dir=False):
     """
     Builds list of interface IDs of segment ASMarkings. Order of IDs depends
     on up flag.
@@ -248,9 +248,9 @@ def _build_interface_list(asms, up=True):
     for i, asm in enumerate(asms):
         isd_as = asm.isd_as()
         hof = asm.pcbm(0).hof()
-        egress = hof.egress_if
-        ingress = hof.ingress_if
-        if up:
+        egress = hof.cons_egress_if
+        ingress = hof.cons_ingress_if
+        if not cons_dir:
             if egress:
                 if_list.append(PathInterface.from_values(isd_as, egress))
             if ingress and i != len(asms) - 1:
@@ -305,7 +305,7 @@ def _copy_hofs(asms, reverse=True):
     return hofs, mtu
 
 
-def _copy_segment_shortcut(segment, index, up=True):
+def _copy_segment_shortcut(segment, index, cons_dir=False):
     """
     Copy a segment for a path shortcut, extracting the upstream
     :any:`HopOpaqueField`, and setting the `up` flag and HOF types
@@ -313,21 +313,22 @@ def _copy_segment_shortcut(segment, index, up=True):
 
     :param PathSegment segment: Segment to copy.
     :param int index: Index at which to start the copy.
-    :param bool up:
-        ``True`` if the path direction is `up` (which will reverse the
-        segment direction), ``False`` otherwise (which will leave the
-        segment direction unchanged).
+    :param bool cons_dir:
+        ``True`` if the path direction is `!up or consDir` (which will leave the
+        segment direction unchanged), 
+        ``False`` otherwise (which will reverse the
+        segment direction).
     :returns:
         The copied :any:`InfoOpaqueField`, path :any:`HopOpaqueField`\s and
         Upstream :any:`HopOpaqueField`.
     """
     info = segment.infoF()
     info.hops -= index
-    info.up_flag = up
+    info.cons_dir_flag = cons_dir
     # Copy segment HOFs
     asms = segment.iter_asms(index)
-    hofs, mtu = _copy_hofs(asms, reverse=up)
-    xovr_idx = -1 if up else 0
+    hofs, mtu = _copy_hofs(asms, reverse=(not cons_dir))
+    xovr_idx = -1 if not cons_dir else 0
     hofs[xovr_idx].xover = True
     # Extract upstream HOF
     upstream_hof = segment.asm(index - 1).pcbm(0).hof()
@@ -348,18 +349,18 @@ def _find_peer_hfs(up_asm, down_asm, peer_revs):
         for down_peer in down_asm.iter_pcbms(1):
             down_hof = down_peer.hof()
             if (up_peer.inIA() == down_ia and down_peer.inIA() == up_ia and
-                    up_peer.p.remoteInIF == down_hof.ingress_if and
-                    up_hof.ingress_if == down_peer.p.remoteInIF):
+                    up_peer.p.remoteInIF == down_hof.cons_ingress_if and
+                    up_hof.cons_ingress_if == down_peer.p.remoteInIF):
                 # Check that there is no valid revocation for the peering
                 # interface.
-                up_rev = peer_revs.get((up_ia, up_hof.ingress_if))
-                down_rev = peer_revs.get((down_ia, down_hof.ingress_if))
+                up_rev = peer_revs.get((up_ia, up_hof.cons_ingress_if))
+                down_rev = peer_revs.get((down_ia, down_hof.cons_ingress_if))
                 if (_skip_peer(up_rev, up_asm.p.hashTreeRoot) or
                         _skip_peer(down_rev, down_asm.p.hashTreeRoot)):
                     logging.debug(
                         "Not using peer %s:%d <-> %s:%d due to revocation."
-                        % (up_ia, up_hof.ingress_if, down_ia,
-                            down_hof.ingress_if))
+                        % (up_ia, up_hof.cons_ingress_if, down_ia,
+                            down_hof.cons_ingress_if))
                     continue
                 hfs.append((up_hof, down_hof, up_peer.p.inMTU))
     return hfs
@@ -391,7 +392,7 @@ def tuples_to_full_paths(tuples):
         core_iof, core_hofs, core_mtu = _copy_segment(
             core_segment, up_segment, down_segment)
         down_iof, down_hofs, down_mtu = _copy_segment(
-            down_segment, (up_segment or core_segment), False, up=False)
+            down_segment, (up_segment or core_segment), False, cons_dir=True)
         args = []
         for iof, hofs in [(up_iof, up_hofs), (core_iof, core_hofs),
                           (down_iof, down_hofs)]:
@@ -409,7 +410,7 @@ def tuples_to_full_paths(tuples):
             down_core = list(down_segment.iter_asms())
         else:
             down_core = []
-        if_list += _build_interface_list(down_core, up=False)
+        if_list += _build_interface_list(down_core, cons_dir=True)
         mtu = _min_mtu(up_mtu, core_mtu, down_mtu)
         path_meta = FwdPathMeta.from_values(path, if_list, mtu)
         res.append(path_meta)

--- a/python/lib/path_store.py
+++ b/python/lib/path_store.py
@@ -384,7 +384,7 @@ class PathStore(object):
             for asm in candidate.pcb.iter_asms():
                 as_disjointness += self.disjointness[asm.isd_as()[1]]
                 if_disjointness += self.disjointness[
-                    asm.pcbm(0).hof().egress_if]
+                    asm.pcbm(0).hof().cons_egress_if]
             candidate.disjointness = (path_disjointness + as_disjointness +
                                       if_disjointness)
             if candidate.disjointness > max_disjointness:

--- a/python/lib/sibra/ext/steady.py
+++ b/python/lib/sibra/ext/steady.py
@@ -115,9 +115,9 @@ class SibraExtSteady(SibraExtBase):
             return
         iof = spkt.path.get_iof()
         hof = spkt.path.get_hof()
-        if iof.up_flag:
-            if1, if2 = hof.egress_if, hof.ingress_if
+        if not iof.cons_dir_flag:
+            if1, if2 = hof.cons_egress_if, hof.cons_ingress_if
         else:
-            if1, if2 = hof.ingress_if, hof.egress_if
+            if1, if2 = hof.cons_ingress_if, hof.cons_egress_if
         prev_raw = self._get_prev_raw(req=True)
         self.req_block.add_hop(if1, if2, prev_raw, key, self.path_ids)

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -202,9 +202,9 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         with self.htroot_if2seglock:
             for asm in pcb.iter_asms():
                 hof = asm.pcbm(0).hof()
-                egress_h = (asm.p.hashTreeRoot, hof.egress_if)
+                egress_h = (asm.p.hashTreeRoot, hof.cons_egress_if)
                 self.htroot_if2seg.setdefault(egress_h, set()).add(segment_id)
-                ingress_h = (asm.p.hashTreeRoot, hof.ingress_if)
+                ingress_h = (asm.p.hashTreeRoot, hof.cons_ingress_if)
                 self.htroot_if2seg.setdefault(ingress_h, set()).add(segment_id)
 
     @abstractmethod
@@ -367,7 +367,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             for asm in seg.iter_asms():
                 for pcbm in asm.iter_pcbms(1):
                     hof = pcbm.hof()
-                    for if_id in [hof.ingress_if, hof.egress_if]:
+                    for if_id in [hof.cons_ingress_if, hof.cons_egress_if]:
                         rev_info = self.revocations.get((asm.isd_as(), if_id))
                         if rev_info:
                             revs_to_add.add(rev_info.copy())
@@ -482,7 +482,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         """
         for asm in seg.iter_asms():
             pcbm = asm.pcbm(0)
-            for if_id in [pcbm.hof().ingress_if, pcbm.hof().egress_if]:
+            for if_id in [pcbm.hof().cons_ingress_if, pcbm.hof().cons_egress_if]:
                 rev_info = self.revocations.get((asm.isd_as(), if_id))
                 if rev_info:
                     logging.debug("Found revoked interface (%d, %s) in segment %s." %

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -1195,7 +1195,7 @@ class SCIONElement(object):
             logging.error("Revocation verification failed. %s", rev_info)
             return False
         for pcbm in as_marking.iter_pcbms():
-            if rev_info.p.ifID in [pcbm.hof().ingress_if, pcbm.hof().egress_if]:
+            if rev_info.p.ifID in [pcbm.hof().cons_ingress_if, pcbm.hof().cons_egress_if]:
                 return True
             if not verify_all:
                 break

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -391,8 +391,8 @@ class SCIONDaemon(SCIONElement):
             for asm in segment.iter_asms():
                 isd_as = asm.isd_as()
                 hof = asm.pcbm(0).hof()
-                egress = hof.egress_if
-                ingress = hof.ingress_if
+                egress = hof.cons_egress_if
+                ingress = hof.cons_ingress_if
                 if ingress:
                     if_list.append(PathInterface.from_values(isd_as, ingress))
                 if egress:

--- a/python/sibra_server/main.py
+++ b/python/sibra_server/main.py
@@ -258,7 +258,7 @@ class SibraServerBase(SCIONElement):
         if not seg:
             del self.dests[isd_as]
             return
-        ifid = seg.last_hof().ingress_if
+        ifid = seg.last_hof().cons_ingress_if
         link_state = self.link_states[ifid]
         link_type = self.link_types[ifid]
         # FIXME(kormat): un-hardcode these bandwidths

--- a/python/sibra_server/util.py
+++ b/python/sibra_server/util.py
@@ -39,10 +39,10 @@ def find_last_ifid(pkt, ext):
         path = pkt.path
         iof = path.get_iof()
         hof = path.get_hof()
-        if iof.up_flag:
-            return hof.egress_if
+        if not iof.cons_dir_flag:
+            return hof.cons_egress_if
         else:
-            return hof.ingress_if
+            return hof.cons_ingress_if
     sof = ext.active_blocks[0].sofs[ext.curr_hop]
     if ext.fwd:
         return sof.ingress

--- a/python/test/lib/packet/opaque_field_test.py
+++ b/python/test/lib/packet/opaque_field_test.py
@@ -45,8 +45,8 @@ class TestHopOpaqueFieldParse(object):
         raw.assert_called_once_with("data", inst.NAME, inst.LEN)
         ntools.eq_(inst.exp_time, 0x2a)
         inst._parse_flags.assert_called_once_with(0x0e)
-        ntools.eq_(inst.ingress_if, 0x0a0)
-        ntools.eq_(inst.egress_if, 0xb0c)
+        ntools.eq_(inst.cons_ingress_if, 0x0a0)
+        ntools.eq_(inst.cons_egress_if, 0xb0c)
         ntools.eq_(inst.mac, bytes.fromhex('012345'))
 
 
@@ -59,8 +59,8 @@ class TestHopOpaqueFieldPack(object):
         inst._pack_flags = create_mock()
         inst._pack_flags.return_value = 0x0e
         inst.exp_time = 0x2a
-        inst.ingress_if = 0x0a0
-        inst.egress_if = 0xb0c
+        inst.cons_ingress_if = 0x0a0
+        inst.cons_egress_if = 0xb0c
         inst.mac = bytes.fromhex('012345')
         expected = bytes.fromhex('0e 2a 0a0b0c 012345')
         # Call
@@ -71,8 +71,8 @@ class TestHopOpaqueFieldPack(object):
         inst._pack_flags = create_mock()
         inst._pack_flags.return_value = 0x0e
         inst.exp_time = 0x2a
-        inst.ingress_if = 0x0a0
-        inst.egress_if = 0xb0c
+        inst.cons_ingress_if = 0x0a0
+        inst.cons_egress_if = 0xb0c
         inst.mac = bytes.fromhex('012345')
         expected = bytes.fromhex('04 2a 0a0b0c')
         # Call
@@ -303,27 +303,27 @@ class TestOpaqueFieldListReverseLabel(object):
 
 class TestOpaqueFieldListReverseUpFlag(object):
     """
-    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_up_flag
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_cons_dir_flag
     """
     def test_basic(self):
         inst = _of_list_setup()
-        iof = create_mock(["up_flag"])
-        iof.up_flag = True
+        iof = create_mock(["cons_dir_flag"])
+        iof.cons_dir_flag = False
         inst._labels["down"] = [iof]
         # Call
-        inst.reverse_up_flag("down")
+        inst.reverse_cons_dir_flag("down")
         # Tests
-        ntools.assert_false(iof.up_flag)
+        ntools.assert_true(iof.cons_dir_flag)
 
     def test_empty(self):
         inst = _of_list_setup()
         # Call
-        inst.reverse_up_flag("down")
+        inst.reverse_cons_dir_flag("down")
 
     def test_label_error(self):
         inst = _of_list_setup()
         # Call
-        ntools.assert_raises(SCIONKeyError, inst.reverse_up_flag, "nope")
+        ntools.assert_raises(SCIONKeyError, inst.reverse_cons_dir_flag, "nope")
 
 
 class TestOpaqueFieldListPack(object):

--- a/python/test/lib/packet/pcb_test.py
+++ b/python/test/lib/packet/pcb_test.py
@@ -83,11 +83,11 @@ class TestPathSegmentGetPath(object):
     @patch("lib.packet.pcb.PathSegment._setup", autospec=True)
     def test_fwd(self, _, info, scion_path):
         inst = self._setup()
-        info.return_value = create_mock_full({"up_flag": True})
+        info.return_value = create_mock_full({"cons_dir_flag": False})
         # Call
         ntools.eq_(inst.get_path(), scion_path.from_values.return_value)
         # Tests
-        ntools.eq_(info.return_value.up_flag, True)
+        ntools.eq_(info.return_value.cons_dir_flag, False)
         scion_path.from_values.assert_called_once_with(
             info.return_value, ["hof 0", "hof 1", "hof 2"])
 
@@ -96,11 +96,11 @@ class TestPathSegmentGetPath(object):
     @patch("lib.packet.pcb.PathSegment._setup", autospec=True)
     def test_reverse(self, _, info, scion_path):
         inst = self._setup()
-        info.return_value = create_mock_full({"up_flag": True})
+        info.return_value = create_mock_full({"cons_dir_flag": False})
         # Call
         ntools.eq_(inst.get_path(True), scion_path.from_values.return_value)
         # Tests
-        ntools.eq_(info.return_value.up_flag, False)
+        ntools.eq_(info.return_value.cons_dir_flag, True)
         scion_path.from_values.assert_called_once_with(
             info.return_value, ["hof 2", "hof 1", "hof 0"])
 

--- a/python/test/lib/path_combinator_test.py
+++ b/python/test/lib/path_combinator_test.py
@@ -144,7 +144,7 @@ class TestPathCombinatorCopySegment(object):
            new_callable=create_mock)
     def test_copy_up(self, copy_hofs):
         seg = create_mock(["iter_asms", "infoF"])
-        info = create_mock(["up_flag"])
+        info = create_mock(["cons_dir_flag"])
         seg.infoF.return_value = info
         hofs = []
         for _ in range(3):
@@ -156,7 +156,7 @@ class TestPathCombinatorCopySegment(object):
         ntools.eq_(path_combinator._copy_segment(seg, True, True),
                    (info, hofs, None))
         # Tests
-        ntools.eq_(info.up_flag, True)
+        ntools.eq_(info.cons_dir_flag, False)
         copy_hofs.assert_called_once_with(seg.iter_asms.return_value,
                                           reverse=True)
         ntools.eq_(hofs[0].xover, True)
@@ -167,11 +167,11 @@ class TestPathCombinatorCopySegment(object):
            new_callable=create_mock)
     def test_copy_down(self, copy_hofs):
         seg = create_mock(["iter_asms", "infoF"])
-        info = create_mock(["up_flag"])
+        info = create_mock(["cons_dir_flag"])
         seg.infoF.return_value = info
         copy_hofs.return_value = "hofs", None
         # Call
-        ntools.eq_(path_combinator._copy_segment(seg, False, False, up=False),
+        ntools.eq_(path_combinator._copy_segment(seg, False, False, cons_dir=True),
                    (info, "hofs", None))
         # Tests
         copy_hofs.assert_called_once_with(seg.iter_asms.return_value,
@@ -268,7 +268,7 @@ class TestPathCombinatorJoinCrossover(PathCombinatorJoinShortcutsBase):
             path_combinator._join_xovr(up_segment, down_segment, point)[0],
             path_meta)
         copy_segment.assert_any_call(up_segment, 1)
-        copy_segment.assert_any_call(down_segment, 2, up=False)
+        copy_segment.assert_any_call(down_segment, 2, cons_dir=True)
         ntools.eq_(build_list.call_count, 1)
 
 
@@ -293,7 +293,7 @@ class TestPathCombinatorJoinPeer(PathCombinatorJoinShortcutsBase):
         ntools.eq_(path_combinator._join_peer(
             up_segment, down_segment, point, peer_revs)[0], path_meta)
         copy_segment.assert_any_call(up_segment, 1)
-        copy_segment.assert_any_call(down_segment, 2, up=False)
+        copy_segment.assert_any_call(down_segment, 2, cons_dir=True)
         ntools.eq_(build_list.call_count, 2)
 
 
@@ -332,21 +332,21 @@ class TestPathCombinatorBuildShortcutInterfaceList(object):
         if_list = path_combinator._build_shortcut_interface_list(
             up_seg, up_idx, down_seg, down_idx, peers)
         assert_these_calls(build_if_list, [call(["B", "A"]),
-                           call(["C", "D"], up=False)])
+                           call(["C", "D"], cons_dir=True)])
         if peers:
             up_hof, down_hof = peers
             ntools.eq_(
-                if_list, [PathInterface.from_values(11, up_hof.ingress_if),
-                          PathInterface.from_values(12, down_hof.ingress_if)])
+                if_list, [PathInterface.from_values(11, up_hof.cons_ingress_if),
+                          PathInterface.from_values(12, down_hof.cons_ingress_if)])
 
     def test_xovr(self):
         yield self._check_xovr_peers, None
 
     def test_peers(self):
-        up_hof = create_mock(["ingress_if"])
-        up_hof.ingress_if = 3
-        down_hof = create_mock(["ingress_if"])
-        down_hof.ingress_if = 4
+        up_hof = create_mock(["cons_ingress_if"])
+        up_hof.cons_ingress_if = 3
+        down_hof = create_mock(["cons_ingress_if"])
+        down_hof.cons_ingress_if = 4
         yield self._check_xovr_peers, (up_hof, down_hof)
 
 
@@ -354,34 +354,34 @@ class TestPathCombinatorBuildInterfaceList(object):
     """
     Unit tests for lib.path_combinator._build_interface_list
     """
-    def _check_up_down(self, up):
+    def _check_up_down(self, cons_dir):
         asms = []
         ifid = 0
         for i in range(1, 4):
-            if up:
-                hof = create_mock_full({"egress_if": ifid,
-                                        "ingress_if": ifid + 1})
+            if not cons_dir:
+                hof = create_mock_full({"cons_egress_if": ifid,
+                                        "cons_ingress_if": ifid + 1})
                 if i == 3:
-                    hof.ingress_if = 0
+                    hof.cons_ingress_if = 0
             else:
-                hof = create_mock_full({"egress_if": ifid + 1,
-                                        "ingress_if": ifid})
+                hof = create_mock_full({"cons_egress_if": ifid + 1,
+                                        "cons_ingress_if": ifid})
                 if i == 3:
-                    hof.egress_if = 0
+                    hof.cons_egress_if = 0
             ifid += 2
             pcbm = create_mock_full({"hof()": hof})
             asms.append(create_mock_full({"isd_as()": i, "pcbm()": pcbm}))
-        if_list = path_combinator._build_interface_list(asms, up)
+        if_list = path_combinator._build_interface_list(asms, cons_dir)
         ntools.eq_(if_list, [PathInterface.from_values(1, 1),
                              PathInterface.from_values(2, 2),
                              PathInterface.from_values(2, 3),
                              PathInterface.from_values(3, 4)])
 
     def test_up(self):
-        yield self._check_up_down, True
+        yield self._check_up_down, False
 
     def test_down(self):
-        yield self._check_up_down, False
+        yield self._check_up_down, True
 
 
 class TestPathCombinatorCheckConnected(object):
@@ -446,7 +446,7 @@ class TestPathCombinatorCopySegmentShortcut(object):
     Unit tests for lib.path_combinator._copy_segment_shortcut
     """
     def _setup(self, copy_hofs):
-        info = create_mock(["hops", "up_flag"])
+        info = create_mock(["hops", "cons_dir_flag"])
         info.hops = 10
         upstream_hof = create_mock(["verify_only", "xover"])
         pcbm = create_mock(["hof"])
@@ -471,7 +471,7 @@ class TestPathCombinatorCopySegmentShortcut(object):
                    (info, hofs, upstream_hof, "mtu"))
         # Tests
         ntools.eq_(info.hops, 6)
-        ntools.ok_(info.up_flag)
+        ntools.ok_(not info.cons_dir_flag)
         copy_hofs.assert_called_once_with(seg.iter_asms.return_value,
                                           reverse=True)
         ntools.eq_(hofs[-1].xover, True)
@@ -483,10 +483,10 @@ class TestPathCombinatorCopySegmentShortcut(object):
     def test_down(self, copy_hofs):
         seg, info, hofs, upstream_hof = self._setup(copy_hofs)
         # Call
-        ntools.eq_(path_combinator._copy_segment_shortcut(seg, 7, up=False),
+        ntools.eq_(path_combinator._copy_segment_shortcut(seg, 7, cons_dir=True),
                    (info, hofs, upstream_hof, "mtu"))
         # Tests
-        ntools.assert_false(info.up_flag)
+        ntools.assert_true(info.cons_dir_flag)
         copy_hofs.assert_called_once_with(seg.iter_asms.return_value,
                                           reverse=False)
         ntools.eq_(hofs[0].xover, True)
@@ -511,7 +511,7 @@ class TestPathCombinatorFindPeerHfs(object):
         return up_pcbms, down_pcbms
 
     def _mk_pcbm(self, inIA, remoteInIF, hof_ingress, mtu):
-        hof = create_mock_full({"ingress_if": hof_ingress})
+        hof = create_mock_full({"cons_ingress_if": hof_ingress})
         p = create_mock_full({"remoteInIF": remoteInIF, "inMTU": mtu})
         return create_mock_full({"inIA()": inIA, "p": p, "hof()": hof})
 

--- a/python/test/lib/path_store_test.py
+++ b/python/test/lib/path_store_test.py
@@ -351,12 +351,12 @@ class TestPathStoreUpdateAllDisjointness(object):
             asms = []
             for j in range(pathLength):
                 isdas = 9, id_ + j + 1
-                hof = create_mock_full({'egress_if': isdas[1] + pathLength})
+                hof = create_mock_full({'cons_egress_if': isdas[1] + pathLength})
                 pcbm = create_mock_full({'hof()': hof})
                 asms.append(create_mock_full({
                     "isd_as()": isdas, "pcbm()": pcbm}))
                 inst.disjointness[isdas[1]] = 1.0
-                inst.disjointness[hof.egress_if] = 1.0
+                inst.disjointness[hof.cons_egress_if] = 1.0
             pcb = create_mock_full({"iter_asms()": asms})
             record = create_mock_full(
                 {'pcb': pcb, 'disjointness': 0, 'id': id_})

--- a/python/test/lib/sibra/ext/steady_test.py
+++ b/python/test/lib/sibra/ext/steady_test.py
@@ -63,14 +63,14 @@ class TestSibraExtSteadyAddHop(object):
         # Tests
         super_addhop.assert_called_once_with(inst, "key")
 
-    def _check_setup(self, up):
+    def _check_setup(self, cons_dir):
         inst = SibraExtSteady()
         inst._get_prev_raw = create_mock()
         inst.setup = True
         inst.path_ids = "path ids"
-        iof = create_mock(["up_flag"])
-        iof.up_flag = up
-        hof = create_mock(["egress_if", "ingress_if"])
+        iof = create_mock(["cons_dir_flag"])
+        iof.cons_dir_flag = cons_dir
+        hof = create_mock(["cons_egress_if", "cons_ingress_if"])
         path = create_mock(["get_hof", "get_iof"])
         path.get_iof.return_value = iof
         path.get_hof.return_value = hof
@@ -81,18 +81,18 @@ class TestSibraExtSteadyAddHop(object):
         # Call
         inst._add_hop("key", spkt)
         # Tests
-        if up:
+        if not cons_dir:
             req.add_hop.assert_called_once_with(
-                hof.egress_if, hof.ingress_if, inst._get_prev_raw.return_value,
+                hof.cons_egress_if, hof.cons_ingress_if, inst._get_prev_raw.return_value,
                 "key", "path ids")
         else:
             req.add_hop.assert_called_once_with(
-                hof.ingress_if, hof.egress_if, inst._get_prev_raw.return_value,
+                hof.cons_ingress_if, hof.cons_egress_if, inst._get_prev_raw.return_value,
                 "key", "path ids")
 
     def test_setup(self):
-        yield self._check_setup, True
         yield self._check_setup, False
+        yield self._check_setup, True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make up/down ingress/egress less ambiguous for paths, fixes #1479

- `up` becomes `!consDir` (as the current "up" is the opposite of the construction direction)
- `ingress` becomes `consIngress`
- `egress` becomes `consEgress`
